### PR TITLE
Fix: inline tables syntax in fpm.toml.

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -5,26 +5,24 @@ author = "John S. Urban"
 maintainer = "urbanjost@comcast.net"
 copyright = "2020 John S. Urban"
 
+# unit test program
+test = [ { name="runTests", source-dir="test", main="main.f90" } ]
+
+# demo programs
+executable = [ { name="demo1", source-dir="PROGRAMS/demo1", main="demo1.f90" },
+               { name="demo2", source-dir="PROGRAMS/demo2", main="demo2.f90" },
+               { name="demo3", source-dir="PROGRAMS/demo3", main="demo3.f90" },
+               { name="demo4", source-dir="PROGRAMS/demo4", main="demo4.f90" },
+               { name="demo5", source-dir="PROGRAMS/demo5", main="demo5.f90" },
+               { name="demo6", source-dir="PROGRAMS/demo6", main="demo6.f90" },
+               { name="demo7", source-dir="PROGRAMS/demo7", main="demo7.f90" },
+               { name="demo_check_commandline", source-dir="PROGRAMS/demos/check_commandline", main="check_commandline.f90" },
+               { name="demo_commandline",       source-dir="PROGRAMS/demos/commandline",       main="commandline.f90" },
+               { name="demo_M_CLI",             source-dir="PROGRAMS/demos/M_CLI",             main="M_CLI.f90" },
+               { name="demo_print_dictionary",  source-dir="PROGRAMS/demos/print_dictionary",  main="print_dictionary.f90" } ]
+
+
 [library]
 source-dir="src"
 
-# unit test program
 
-[[test]]   name="runTests"                 source-dir="test"                     main="main.f90"
-
-# demo programs
-
-[[executable]]   name="demo1"  source-dir="PROGRAMS/demo1"  main="demo1.f90"
-[[executable]]   name="demo2"  source-dir="PROGRAMS/demo2"  main="demo2.f90"
-[[executable]]   name="demo3"  source-dir="PROGRAMS/demo3"  main="demo3.f90"
-[[executable]]   name="demo4"  source-dir="PROGRAMS/demo4"  main="demo4.f90"
-[[executable]]   name="demo5"  source-dir="PROGRAMS/demo5"  main="demo5.f90"
-[[executable]]   name="demo6"  source-dir="PROGRAMS/demo6"  main="demo6.f90"
-[[executable]]   name="demo7"  source-dir="PROGRAMS/demo7"  main="demo7.f90"
-
-# sample programs extracted from manpages:
-
-[[executable]]   name="demo_check_commandline"  source-dir="PROGRAMS/demos/check_commandline"  main="check_commandline.f90"
-[[executable]]   name="demo_commandline"        source-dir="PROGRAMS/demos/commandline"        main="commandline.f90"
-[[executable]]   name="demo_M_CLI"              source-dir="PROGRAMS/demos/M_CLI"              main="M_CLI.f90"
-[[executable]]   name="demo_print_dictionary"   source-dir="PROGRAMS/demos/print_dictionary"   main="print_dictionary.f90"


### PR DESCRIPTION
Fixes #2. I've used inline tables to keep the same compact syntax that you had originally.
I had to move the library section to the bottom otherwise 'test' and 'executable' would now be sub-members of it.

In the near future `fpm.toml` will be validated automatically during pull requests to [fpm-registry](https://github.com/fortran-lang/fpm-registry).